### PR TITLE
if notify-send is missing, try with kdialog (plasma/kde5), fix issue #1

### DIFF
--- a/src/drosh.py
+++ b/src/drosh.py
@@ -33,7 +33,11 @@ class Screenshot(object):
         """
         Send a desktop message
         """
-        subprocess.call(['notify-send', title, body])
+        try:
+            subprocess.call(['notify-send', title, body])
+        except FileNotFoundError:
+            # Try with kdialog
+            subprocess.run(['kdialog', '--title', title, '--passivepopup', body, '5'])
 
     def create_shared_link(self, path):
         """


### PR DESCRIPTION
This add supports for users who use kde5/plasma. It should fix #1 